### PR TITLE
Adição de Object.ToDescriptionString()

### DIFF
--- a/Pandemonium.Test/Extensions/Object/ToDescriptionStringTests.cs
+++ b/Pandemonium.Test/Extensions/Object/ToDescriptionStringTests.cs
@@ -7,7 +7,7 @@ namespace Pandemonium.Test.Extensions.Object
     public class ToDescriptionStringTests
     {
         [Fact]
-        public void Should_Return_String_Description_When_Object_Not_Null()
+        public void Should_Return_String_Description_When_Anonymous_Object_Not_Null()
         {
             var @object = new
             {
@@ -24,5 +24,37 @@ namespace Pandemonium.Test.Extensions.Object
             string description = @object.ToDescriptionString();
             Assert.NotEmpty(description);
         }
+
+        [Fact]
+        public void Should_Return_String_Description_When_Class_Object_Not_Null()
+        {
+            var @object = new SampleClass
+            {
+                FirstName = "FirstName",
+                SecondName = "SecondName"
+            };
+
+            string description = @object.ToDescriptionString();
+            Assert.NotEmpty(description);
+        }
+
+        [Fact]
+        public void Should_Not_Return_String_Description_When_Object_Is_Null()
+        {
+            object @object = null;
+
+            string description = @object.ToDescriptionString();
+            Assert.Empty(description);
+        }
+    }
+
+    internal class SampleClass
+    {
+        public static string StaticValue { get; } = "Static";
+        public string FirstName { get; set; }
+        public string SecondName { get; set; }
+        public string FullName => $"{FirstName} {SecondName}";
+        public object NullValue { get; } = null;
+        public DateTime? NullableValue { get; } = DateTime.Now;
     }
 }

--- a/Pandemonium.Test/Extensions/Object/ToDescriptionStringTests.cs
+++ b/Pandemonium.Test/Extensions/Object/ToDescriptionStringTests.cs
@@ -39,6 +39,15 @@ namespace Pandemonium.Test.Extensions.Object
         }
 
         [Fact]
+        public void Should_Return_String_Description_When_Primitive_Object_Not_Null()
+        {
+            var @object = "Test";
+
+            string description = @object.ToDescriptionString();
+            Assert.NotEmpty(description);
+        }
+
+        [Fact]
         public void Should_Not_Return_String_Description_When_Object_Is_Null()
         {
             object @object = null;

--- a/Pandemonium.Test/Extensions/Object/ToDescriptionStringTests.cs
+++ b/Pandemonium.Test/Extensions/Object/ToDescriptionStringTests.cs
@@ -23,7 +23,6 @@ namespace Pandemonium.Test.Extensions.Object
 
             string description = @object.ToDescriptionString();
             Assert.NotEmpty(description);
-            Console.WriteLine(description);
         }
     }
 }

--- a/Pandemonium.Test/Extensions/Object/ToDescriptionStringTests.cs
+++ b/Pandemonium.Test/Extensions/Object/ToDescriptionStringTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Pandemonium.Test.Extensions.Object
+{
+    public class ToDescriptionStringTests
+    {
+        [Fact]
+        public void Should_Return_String_Description_When_Object_Not_Null()
+        {
+            var @object = new
+            {
+                Name = "Flano",
+                Age = 20,
+                BirthDate = new DateTime(1990, 01, 01),
+                Contacts = new List<string>
+                {
+                    "(84) 2654-8862",
+                    "(84) 2654-8862"
+                }
+            };
+
+            string description = @object.ToDescriptionString();
+            Assert.NotEmpty(description);
+            Console.WriteLine(description);
+        }
+    }
+}

--- a/Pandemonium/Extensions/Object/Object.ToDescriptionString.cs
+++ b/Pandemonium/Extensions/Object/Object.ToDescriptionString.cs
@@ -12,46 +12,23 @@ namespace Pandemonium
             if (@this == null)
                 return string.Empty;
 
-            return ToDescriptionString(@this, new StringBuilder(), 0).ToString();
+            return ToDescriptionString(@this, new StringBuilder()).ToString();
         }
 
-        private static StringBuilder ToDescriptionString(object @this, StringBuilder stringBuilder, int indentCount)
+        private static StringBuilder ToDescriptionString(object @this, StringBuilder stringBuilder)
         {
             if (@this == null)
                 return stringBuilder;
-
-            string indentation = new string(' ', indentCount);
 
             Type objType = @this.GetType();
             PropertyInfo[] properties = objType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
             foreach (PropertyInfo property in properties)
             {
-                object value = property.GetValue(@this, null);
-                if (value is IEnumerable)
-                {
-                    var enumeration = value as IEnumerable;
-                    foreach (var element in enumeration)
-                    {
-                        ToDescriptionString(element, stringBuilder, indentCount + 3);
-                    }
-                }
+                object @value = property.GetValue(@this);
+                if (property.PropertyType.ToString() == @value.ToString())
+                    stringBuilder.AppendLine($"{property.Name}: {@value}");
                 else
-                {
-                    if (property.PropertyType.Assembly == objType.Assembly)
-                    {
-                        stringBuilder
-                            .AppendFormat("{0}{1}:", indentation, property.Name)
-                            .AppendLine();
-
-                        ToDescriptionString(value, stringBuilder, indentCount + 2);
-                    }
-                    else
-                    {
-                        stringBuilder
-                            .AppendFormat("{0}{1}: {2}", indentation, property.Name, value)
-                            .AppendLine();
-                    }
-                }
+                    stringBuilder.AppendLine($"{property.Name}: {@value} [{property.PropertyType}]");
             }
             return stringBuilder;
         }

--- a/Pandemonium/Extensions/Object/Object.ToDescriptionString.cs
+++ b/Pandemonium/Extensions/Object/Object.ToDescriptionString.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Reflection;
 using System.Text;
+using System.Linq;
 
 namespace Pandemonium
 {
@@ -21,17 +22,25 @@ namespace Pandemonium
                 return stringBuilder;
 
             Type objType = @this.GetType();
-            PropertyInfo[] properties = objType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+
+            if (objType.ToString() == @this.ToString())
+                stringBuilder.AppendLine(string.Format("[{0}]:", objType));
+            else
+                stringBuilder.AppendLine(string.Format("[{0}]: {1}", objType, @this));
+
+            var properties = objType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+                .Where(p => p.GetIndexParameters().Length == 0);
+
             foreach (PropertyInfo property in properties)
             {
                 object @value = property.GetValue(@this);
 
                 if (@value.Null())
-                    stringBuilder.AppendLine(string.Format("{0}: null [{1}]", property.Name, property.PropertyType));
+                    stringBuilder.AppendLine(string.Format("    {0}: null [{1}]", property.Name, property.PropertyType));
                 else if (property.PropertyType.ToString() == @value.ToString())
-                    stringBuilder.AppendLine(string.Format("{0}: {1}", property.Name, @value));
+                    stringBuilder.AppendLine(string.Format("    {0}: {1}", property.Name, @value));
                 else
-                    stringBuilder.AppendLine(string.Format("{0}: {1} [{2}]", property.Name, @value, property.PropertyType));
+                    stringBuilder.AppendLine(string.Format("    {0}: {1} [{2}]", property.Name, @value, property.PropertyType));
             }
             return stringBuilder;
         }

--- a/Pandemonium/Extensions/Object/Object.ToDescriptionString.cs
+++ b/Pandemonium/Extensions/Object/Object.ToDescriptionString.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections;
+using System.Reflection;
+using System.Text;
+
+namespace Pandemonium
+{
+    public static partial class Methods
+    {
+        public static string ToDescriptionString(this object @this)
+        {
+            if (@this == null)
+                return string.Empty;
+
+            return ToDescriptionString(@this, new StringBuilder(), 0).ToString();
+        }
+
+        private static StringBuilder ToDescriptionString(object @this, StringBuilder stringBuilder, int indentCount)
+        {
+            if (@this == null)
+                return stringBuilder;
+
+            string indentation = new string(' ', indentCount);
+
+            Type objType = @this.GetType();
+            PropertyInfo[] properties = objType.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
+            foreach (PropertyInfo property in properties)
+            {
+                object value = property.GetValue(@this, null);
+                if (value is IEnumerable)
+                {
+                    var enumeration = value as IEnumerable;
+                    foreach (var element in enumeration)
+                    {
+                        ToDescriptionString(element, stringBuilder, indentCount + 3);
+                    }
+                }
+                else
+                {
+                    if (property.PropertyType.Assembly == objType.Assembly)
+                    {
+                        stringBuilder
+                            .AppendFormat("{0}{1}:", indentation, property.Name)
+                            .AppendLine();
+
+                        ToDescriptionString(value, stringBuilder, indentCount + 2);
+                    }
+                    else
+                    {
+                        stringBuilder
+                            .AppendFormat("{0}{1}: {2}", indentation, property.Name, value)
+                            .AppendLine();
+                    }
+                }
+            }
+            return stringBuilder;
+        }
+    }
+}

--- a/Pandemonium/Extensions/Object/Object.ToDescriptionString.cs
+++ b/Pandemonium/Extensions/Object/Object.ToDescriptionString.cs
@@ -25,10 +25,13 @@ namespace Pandemonium
             foreach (PropertyInfo property in properties)
             {
                 object @value = property.GetValue(@this);
-                if (property.PropertyType.ToString() == @value.ToString())
-                    stringBuilder.AppendLine($"{property.Name}: {@value}");
+
+                if (@value.Null())
+                    stringBuilder.AppendLine(string.Format("{0}: null [{1}]", property.Name, property.PropertyType));
+                else if (property.PropertyType.ToString() == @value.ToString())
+                    stringBuilder.AppendLine(string.Format("{0}: {1}", property.Name, @value));
                 else
-                    stringBuilder.AppendLine($"{property.Name}: {@value} [{property.PropertyType}]");
+                    stringBuilder.AppendLine(string.Format("{0}: {1} [{2}]", property.Name, @value, property.PropertyType));
             }
             return stringBuilder;
         }


### PR DESCRIPTION
Motivado pelo novo ToString dos records do .Net 5, criei uma versão meia boca pra listar os valores das propriedades públicas de um objeto.